### PR TITLE
그림 모음장 페이지 오류 수정 및 기능 개선

### DIFF
--- a/app.py
+++ b/app.py
@@ -81,7 +81,8 @@ def draw_word(word_id):
     word = db.get_word(word_id)
     if not word:
         abort(404)
-    return render_template('drawing.html', word=word)
+    existing_drawing = db.get_drawing_by_word_id(word_id)
+    return render_template('drawing.html', word=word, existing_drawing=existing_drawing)
 
 
 @app.route('/collection')
@@ -123,6 +124,8 @@ def api_save_drawing():
     if not image_data.startswith('data:image/'):
         return jsonify({'success': False, 'error': '이미지 형식이 잘못됐어요'}), 400
 
+    replace_drawing_id = data.get('replace_drawing_id')
+
     try:
         header, encoded = image_data.split(',', 1)
         img_bytes = base64.b64decode(encoded)
@@ -134,6 +137,16 @@ def api_save_drawing():
             f.write(img_bytes)
 
         relative_path = f"static/generated/drawings/{filename}"
+
+        # 수정 모드: 기존 그림 삭제 후 새로 저장
+        if replace_drawing_id:
+            old = db.get_drawing_with_data(replace_drawing_id)
+            if old and old.get('file_path'):
+                old_file = os.path.join(os.path.dirname(__file__), old['file_path'])
+                if os.path.exists(old_file):
+                    os.remove(old_file)
+            db.delete_drawing(replace_drawing_id)
+
         drawing_id = db.save_drawing(word_id, image_data, relative_path)
 
         return jsonify({'success': True, 'drawing_id': drawing_id})
@@ -253,6 +266,15 @@ def api_words():
 def api_drawings():
     drawings = db.get_all_drawings()
     return jsonify(drawings)
+
+
+@app.route('/api/drawings/<int:drawing_id>', methods=['DELETE'])
+def api_delete_drawing(drawing_id):
+    try:
+        db.delete_drawing(drawing_id)
+        return jsonify({'success': True})
+    except Exception as e:
+        return jsonify({'success': False, 'error': str(e)}), 500
 
 
 if __name__ == '__main__':

--- a/database.py
+++ b/database.py
@@ -199,9 +199,23 @@ def get_all_drawings():
             SELECT d.id, d.word_id, d.file_path, d.created_at,
                    w.korean, w.english, w.emoji, w.category
             FROM drawings d JOIN words w ON d.word_id = w.id
-            ORDER BY d.created_at DESC
+            ORDER BY w.korean ASC
         ''').fetchall()
         return [dict(r) for r in rows]
+
+
+def delete_drawing(drawing_id):
+    with get_db() as conn:
+        conn.execute('DELETE FROM drawings WHERE id=?', (drawing_id,))
+
+
+def get_drawing_by_word_id(word_id):
+    with get_db() as conn:
+        row = conn.execute(
+            'SELECT * FROM drawings WHERE word_id=? ORDER BY created_at DESC LIMIT 1',
+            (word_id,)
+        ).fetchone()
+        return dict(row) if row else None
 
 
 def get_drawing_with_data(drawing_id):

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -586,6 +586,42 @@ body::before {
 /* 플로팅 오버레이 내 카드: JS가 transform 직접 제어 (CSS hover/selected transform 비활성화) */
 #float-overlay .drawing-card:hover    { transform: none; box-shadow: none; }
 #float-overlay .drawing-card.selected { transform: none; }
+#float-overlay .drawing-card:hover .card-actions { opacity: 1; }
+
+/* 카드 액션 버튼 (호버 시 표시) */
+.card-actions {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+}
+.drawing-card:hover .card-actions { opacity: 1; }
+
+.card-action-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255,255,255,0.92);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+  cursor: pointer;
+  font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  transition: transform 0.15s, box-shadow 0.15s;
+}
+.card-action-btn:hover {
+  transform: scale(1.15);
+  box-shadow: 0 4px 10px rgba(0,0,0,0.2);
+}
 
 .drawing-card.disabled { opacity: 0.4; cursor: not-allowed; pointer-events: none; }
 
@@ -902,9 +938,42 @@ audio { width: 100%; border-radius: 8px; }
 .fade-in { animation: fadeIn 0.4s ease both; }
 
 /* ─── 반응형 ────────────────────────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  /* 모음장 헤더: 타이틀과 버튼 줄바꿈 */
+  .collection-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .collection-header > div {
+    flex-wrap: wrap;
+  }
+
+  /* 모바일에서 둥실둥실 버튼 숨김 */
+  #btn-float { display: none !important; }
+
+  /* 도감 그리드: 2열 */
+  .drawings-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+  }
+
+  /* 카드 이미지 높이 축소 */
+  .drawing-card img,
+  .drawing-card > div[style*="height:140px"],
+  .drawing-card > div[style*="height: 140px"] {
+    height: 100px !important;
+  }
+
+  .drawing-card { padding: 12px; }
+  .drawing-card-word { font-size: 0.95rem; }
+}
+
 @media (max-width: 480px) {
   .btn-big { padding: 16px 32px; font-size: 1.2rem; }
-  .drawings-grid { grid-template-columns: repeat(2, 1fr); }
+  .drawings-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+  }
 }
 
 /* ─── 섹션 제목 ─────────────────────────────────────────────────────────────── */

--- a/static/js/canvas.js
+++ b/static/js/canvas.js
@@ -181,10 +181,14 @@
       saveBtn.textContent = '저장 중...';
 
       try {
-        const res = await fetch('/api/drawing/save', {
+        const replaceId = saveBtn.dataset.replaceId;
+      const body = { word_id: parseInt(wordId), image_data: imageData };
+      if (replaceId) body.replace_drawing_id = parseInt(replaceId);
+
+      const res = await fetch('/api/drawing/save', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ word_id: parseInt(wordId), image_data: imageData })
+          body: JSON.stringify(body)
         });
         const data = await res.json();
 
@@ -299,6 +303,18 @@
 
   // ─── 초기화 ─────────────────────────────────────────────────────────────────
   initCanvas();
+
+  // 기존 그림이 있으면 캔버스에 불러오기
+  const existingImageUrl = canvas.dataset.existingImage;
+  if (existingImageUrl) {
+    const img = new Image();
+    img.onload = () => {
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      saveHistory();
+    };
+    img.src = existingImageUrl;
+  }
+
   // 기본 색상 선택 (검정)
   const defaultColorBtn = document.querySelector('.color-btn[data-color="#333333"]');
   if (defaultColorBtn) defaultColorBtn.classList.add('active');

--- a/static/js/collection.js
+++ b/static/js/collection.js
@@ -91,6 +91,53 @@
     card.addEventListener('click', () => { if (!floatMode) toggle(card.dataset.id); });
   });
 
+  // ─── 삭제 핸들러 ────────────────────────────────────────────────
+  async function deleteDrawing(id) {
+    if (!confirm('이 그림을 삭제할까요?')) return;
+    try {
+      const res = await fetch(`/api/drawings/${id}`, { method: 'DELETE' });
+      const data = await res.json();
+      if (data.success) {
+        // 도감 카드 제거
+        const origCard = origCards.find(c => c.dataset.id === String(id));
+        if (origCard) origCard.remove();
+        // 둥실둥실 카드 제거
+        const physState = physCards.find(s => s.id === String(id));
+        if (physState) physState.el.remove();
+        selected.delete(String(id));
+        updateUI();
+      } else {
+        alert('삭제 중 오류가 발생했어요.');
+      }
+    } catch {
+      alert('삭제 중 오류가 발생했어요.');
+    }
+  }
+
+  // 도감 모드 액션 버튼 (수정 + 삭제)
+  origCards.forEach(card => {
+    card.querySelectorAll('.card-action-btn').forEach(btn => {
+      btn.addEventListener('click', e => e.stopPropagation());
+    });
+    const delBtn = card.querySelector('.delete-btn');
+    if (delBtn) delBtn.addEventListener('click', e => {
+      e.stopPropagation();
+      deleteDrawing(card.dataset.id);
+    });
+  });
+
+  // 둥실둥실 모드 액션 버튼 (수정 + 삭제)
+  physCards.forEach(state => {
+    state.el.querySelectorAll('.card-action-btn').forEach(btn => {
+      btn.addEventListener('click', e => e.stopPropagation());
+    });
+    const delBtn = state.el.querySelector('.delete-btn');
+    if (delBtn) delBtn.addEventListener('click', e => {
+      e.stopPropagation();
+      deleteDrawing(state.id);
+    });
+  });
+
   // ─── 선택 토글 ─────────────────────────────────────────────────
   function toggle(id) {
     if (selected.has(id)) {
@@ -177,101 +224,120 @@
     if (floatMode) {
       grid.style.display    = 'none';
       overlay.style.display = 'block';
+      startLoop();
     } else {
       grid.style.display    = '';
       overlay.style.display = 'none';
+      stopLoop();
     }
   }
 
   if (btnFloat) btnFloat.addEventListener('click', () => setMode('float'));
   if (btnGrid)  btnGrid.addEventListener('click',  () => setMode('grid'));
 
-  // 시작: 플로팅 모드
-  setMode('float');
+  // 창 크기 변경 시 모드 자동 전환
+  window.addEventListener('resize', () => {
+    if (window.innerWidth <= 768 && floatMode) setMode('grid');
+    else if (window.innerWidth > 768 && !floatMode) setMode('float');
+  });
 
   // ─── 물리 루프 ─────────────────────────────────────────────────
-  function tick() {
-    if (floatMode) {
-      const b = getBounds();
+  let rafId = null;
 
-      physCards.forEach(s => {
-        if (!s.ready || s.hovered) return;
-        s.x += s.vx;
-        s.y += s.vy;
-
-        if (s.x < b.left)            { s.x = b.left;            s.vx =  Math.abs(s.vx); }
-        if (s.x + CARD_W > b.right)  { s.x = b.right  - CARD_W; s.vx = -Math.abs(s.vx); }
-        if (s.y < b.top)             { s.y = b.top;             s.vy =  Math.abs(s.vy); }
-        if (s.y + CARD_H > b.bottom) { s.y = b.bottom - CARD_H; s.vy = -Math.abs(s.vy); }
-
-        s.vx *= DAMP;
-        s.vy *= DAMP;
-
-        // 최소 속도 유지
-        const spd = Math.hypot(s.vx, s.vy);
-        if (spd < 0.6) {
-          // 완전 랜덤 대신 현재 속도 방향 유지하며 가속 (더 자연스러움)
-          const ang = spd > 0.01 ? Math.atan2(s.vy, s.vx) : Math.random() * Math.PI * 2;
-          s.vx = Math.cos(ang) * SPEED;
-          s.vy = Math.sin(ang) * SPEED;
-        }
-        // 최대 속도 제한 (충돌 누적으로 인한 속도 폭발 방지)
-        else if (spd > MAX_SPEED) {
-          s.vx = s.vx / spd * MAX_SPEED;
-          s.vy = s.vy / spd * MAX_SPEED;
-        }
-      });
-
-      // 카드 간 스프링 반발 (임펄스 없이 힘만 → 다중 충돌에도 안정적)
-      for (let i = 0; i < physCards.length; i++) {
-        for (let j = i + 1; j < physCards.length; j++) {
-          const a = physCards[i], c = physCards[j];
-          if (!a.ready || !c.ready) continue;
-          const dx = (c.x + CARD_W / 2) - (a.x + CARD_W / 2);
-          const dy = (c.y + CARD_H / 2) - (a.y + CARD_H / 2);
-          const dist = Math.hypot(dx, dy);
-          const minD = RADIUS * 2;
-          if (dist < minD && dist > 0.01) {
-            const nx = dx / dist, ny = dy / dist;
-            const f = 0.55 * (1 - dist / minD); // 겹칠수록 강하게
-            if (!a.hovered) { a.vx -= nx * f; a.vy -= ny * f; }
-            if (!c.hovered) { c.vx += nx * f; c.vy += ny * f; }
-          }
-        }
-      }
-
-      // 호버 카드 주변 강한 반발 (호버 카드는 고정, 주변만 밀어냄)
-      physCards.forEach(s => {
-        if (!s.hovered || !s.ready) return;
-        const cx = s.x + CARD_W / 2, cy = s.y + CARD_H / 2;
-        physCards.forEach(o => {
-          if (o === s || !o.ready) return;
-          const dx = (o.x + CARD_W / 2) - cx;
-          const dy = (o.y + CARD_H / 2) - cy;
-          const dist = Math.hypot(dx, dy);
-          if (dist < REPEL_R && dist > 0.01) {
-            const f = REPEL_F * (1 - dist / REPEL_R);
-            o.vx += (dx / dist) * f;
-            o.vy += (dy / dist) * f;
-          }
-        });
-      });
-
-      // DOM 반영
-      physCards.forEach(s => {
-        if (!s.ready) return;
-        const scale = s.hovered ? 1.1 : 1;
-        s.el.style.transform = `translate(${s.x}px, ${s.y}px) scale(${scale})`;
-        s.el.style.zIndex    = s.hovered ? '20' : '10';
-        s.el.style.boxShadow = s.hovered
-          ? '0 16px 40px rgba(0,0,0,0.22)'
-          : (selected.has(s.id) ? '0 0 0 4px rgba(255,107,157,0.35)' : '');
-      });
-    }
-    requestAnimationFrame(tick);
+  function startLoop() {
+    if (rafId) return;
+    rafId = requestAnimationFrame(tick);
   }
 
-  requestAnimationFrame(tick);
+  function stopLoop() {
+    if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
+  }
+
+  function tick() {
+    rafId = null;
+    if (!floatMode) return; // 도감 모드면 루프 종료
+
+    const b = getBounds();
+
+    physCards.forEach(s => {
+      if (!s.ready || s.hovered) return;
+      s.x += s.vx;
+      s.y += s.vy;
+
+      if (s.x < b.left)            { s.x = b.left;            s.vx =  Math.abs(s.vx); }
+      if (s.x + CARD_W > b.right)  { s.x = b.right  - CARD_W; s.vx = -Math.abs(s.vx); }
+      if (s.y < b.top)             { s.y = b.top;             s.vy =  Math.abs(s.vy); }
+      if (s.y + CARD_H > b.bottom) { s.y = b.bottom - CARD_H; s.vy = -Math.abs(s.vy); }
+
+      s.vx *= DAMP;
+      s.vy *= DAMP;
+
+      // 최소 속도 유지
+      const spd = Math.hypot(s.vx, s.vy);
+      if (spd < 0.6) {
+        const ang = spd > 0.01 ? Math.atan2(s.vy, s.vx) : Math.random() * Math.PI * 2;
+        s.vx = Math.cos(ang) * SPEED;
+        s.vy = Math.sin(ang) * SPEED;
+      }
+      // 최대 속도 제한 (충돌 누적으로 인한 속도 폭발 방지)
+      else if (spd > MAX_SPEED) {
+        s.vx = s.vx / spd * MAX_SPEED;
+        s.vy = s.vy / spd * MAX_SPEED;
+      }
+    });
+
+    // 카드 간 스프링 반발
+    for (let i = 0; i < physCards.length; i++) {
+      for (let j = i + 1; j < physCards.length; j++) {
+        const a = physCards[i], c = physCards[j];
+        if (!a.ready || !c.ready) continue;
+        const dx = (c.x + CARD_W / 2) - (a.x + CARD_W / 2);
+        const dy = (c.y + CARD_H / 2) - (a.y + CARD_H / 2);
+        const dist = Math.hypot(dx, dy);
+        const minD = RADIUS * 2;
+        if (dist < minD && dist > 0.01) {
+          const nx = dx / dist, ny = dy / dist;
+          const f = 0.55 * (1 - dist / minD);
+          if (!a.hovered) { a.vx -= nx * f; a.vy -= ny * f; }
+          if (!c.hovered) { c.vx += nx * f; c.vy += ny * f; }
+        }
+      }
+    }
+
+    // 호버 카드 주변 강한 반발
+    physCards.forEach(s => {
+      if (!s.hovered || !s.ready) return;
+      const cx = s.x + CARD_W / 2, cy = s.y + CARD_H / 2;
+      physCards.forEach(o => {
+        if (o === s || !o.ready) return;
+        const dx = (o.x + CARD_W / 2) - cx;
+        const dy = (o.y + CARD_H / 2) - cy;
+        const dist = Math.hypot(dx, dy);
+        if (dist < REPEL_R && dist > 0.01) {
+          const f = REPEL_F * (1 - dist / REPEL_R);
+          o.vx += (dx / dist) * f;
+          o.vy += (dy / dist) * f;
+        }
+      });
+    });
+
+    // DOM 반영
+    physCards.forEach(s => {
+      if (!s.ready) return;
+      const scale = s.hovered ? 1.1 : 1;
+      s.el.style.transform = `translate(${s.x}px, ${s.y}px) scale(${scale})`;
+      s.el.style.zIndex    = s.hovered ? '20' : '10';
+      s.el.style.boxShadow = s.hovered
+        ? '0 16px 40px rgba(0,0,0,0.22)'
+        : (selected.has(s.id) ? '0 0 0 4px rgba(255,107,157,0.35)' : '');
+    });
+
+    rafId = requestAnimationFrame(tick);
+  }
+
+  // 시작: 모바일(768px 이하)은 도감, 그 외는 플로팅
+  setMode(window.innerWidth <= 768 ? 'grid' : 'float');
+
 
   // ─── 동화 만들기 버튼 ──────────────────────────────────────────
   if (makeBtn) {

--- a/templates/collection.html
+++ b/templates/collection.html
@@ -24,8 +24,12 @@
   {% if drawings %}
   <div class="drawings-grid">
     {% for drawing in drawings %}
-    <div class="drawing-card fade-in" data-id="{{ drawing.id }}" style="animation-delay: {{ loop.index0 * 0.05 }}">
+    <div class="drawing-card fade-in" data-id="{{ drawing.id }}" data-word-id="{{ drawing.word_id }}" style="animation-delay: {{ loop.index0 * 0.05 }}">
       <div class="selected-badge">✓</div>
+      <div class="card-actions">
+        <a href="/draw/{{ drawing.word_id }}" class="card-action-btn edit-btn" title="다시 그리기">✏️</a>
+        <button class="card-action-btn delete-btn" data-id="{{ drawing.id }}" title="삭제">🗑️</button>
+      </div>
       {% if drawing.file_path %}
       <img src="{{ url_for('static', filename=drawing.file_path.replace('static/', '')) }}" alt="{{ drawing.korean }}"
         onerror="this.style.display='none'; this.nextElementSibling.style.display='flex'">

--- a/templates/drawing.html
+++ b/templates/drawing.html
@@ -94,13 +94,19 @@
 
   <!-- ── 그림판 (캔버스) ── -->
   <div id="canvas-container" class="canvas-container fade-in">
-    <canvas id="drawing-canvas"></canvas>
+    <canvas id="drawing-canvas"
+      {% if existing_drawing %}
+        data-existing-image="{{ url_for('static', filename=existing_drawing.file_path.replace('static/', '')) }}"
+        data-existing-id="{{ existing_drawing.id }}"
+      {% endif %}
+    ></canvas>
   </div>
 
   <!-- ── 하단 완료 버튼 ── -->
   <div class="drawing-bottom fade-in">
-    <a href="/main" class="btn btn-white">← 메인으로</a>
-    <button class="btn btn-green btn-done" id="save-btn" data-word-id="{{ word.id }}">
+    <a href="/collection" class="btn btn-white">← 모음장으로</a>
+    <button class="btn btn-green btn-done" id="save-btn" data-word-id="{{ word.id }}"
+      {% if existing_drawing %}data-replace-id="{{ existing_drawing.id }}"{% endif %}>
       ✅ 다 그렸어요!
     </button>
   </div>


### PR DESCRIPTION
그림 모음장 수정 및 기능 개선




### `collection.js` — 창 크기 변경 시 플로팅 카드 위치 초기화 없음 (✅)

- 브라우저 창을 리사이즈하면 `getBounds()`는 새 크기를 반환하지만 기존 카드 위치가 재배치되지 않아 **카드가 경계 밖으로 벗어날 수 있음**
- `window.resize` 이벤트 핸들러 부재 ⇒ react, react native등 관련된거 쓰면 창을 줄여도 기능들이 잘 작동함

-> 현재 리액트로 변경하기엔 미니 프로젝트 기간이 너무 부족함.
현재는 수동 반응형으로 동작하게 해놨음


### 모바일에서 플로팅 모드 성능(✅)

- `requestAnimationFrame` 루프가 항상 실행 중이며, 도감 모드(`floatMode=false`)일 때도 `tick()`이 계속 호출됨
-  (`collection.js` 194라인 조건 분기만 있고 루프 자체는 멈추지 않음)
- 저사양 모바일 기기에서 배터리 소모 및 발열 원인이 될 수 있음

→ 그림 단어 모음장 들어가서 ( 둥실 둥실 ) 버튼이 ON 되어있을 때에만 모델 동작 하게 구현

→ 다른 페이지이거나 (도감 형식 )  이 체크 되어있으면 모델 OFF

### 그림 삭제 기능(✅)

- 모음장에서 잘못 그린 그림을 삭제할 수 없음
- API(`DELETE /api/drawing/{id}`)와 UI 버튼이 없음
- 그림이 쌓이면 동화 선택 시 불필요한 그림까지 노출됨

### [있으면 좋을 것]  그림 다시 그리기 기능(✅)

- 저장된 그림을 수정하거나 다시 그리는 경로가 없음
- `/draw/<word_id>` 라우트는 있지만 모음장에서 해당 단어로 돌아가는 버튼이 없음