### PR TITLE
feat: 동화 페이지 그림 플로팅 개선 및 UI 수정

### DIFF
--- a/services/image_service.py
+++ b/services/image_service.py
@@ -149,39 +149,6 @@ def generate_moral_collage(moral_text, all_drawings):
             
             bg_img.alpha_composite(d_img, (px, py))
             
-        # 텍스트 렌더링
-        from PIL import ImageDraw, ImageFont
-        draw = ImageDraw.Draw(bg_img)
-        # '맑은고딕볼드' 폰트 시도
-        font_path = "C:\\Windows\\Fonts\\malgunbd.ttf"
-        try:
-            title_font = ImageFont.truetype(font_path, 36)
-            body_font = ImageFont.truetype(font_path, 24)
-        except:
-            title_font = ImageFont.load_default()
-            body_font = ImageFont.load_default()
-
-        # 제목 (PIL은 이모지 렌더링 불가 → 텍스트 별표 기호 사용)
-        draw.text((bg_w//2, int(bg_h * 0.65)), "★ 이야기의 교훈 ★", fill=(60, 60, 60, 255), font=title_font, anchor="mm")
-        
-        # 교훈 내용 (자동 줄바꿈)
-        lines = []
-        words = moral_text.split()
-        current_line = ""
-        for word in words:
-            test_line = current_line + " " + word
-            if draw.textbbox((0, 0), test_line, font=body_font)[2] < bg_w - 80:
-                current_line = test_line
-            else:
-                lines.append(current_line.strip())
-                current_line = word
-        lines.append(current_line.strip())
-        
-        y_text = int(bg_h * 0.73)
-        for line in lines:
-            draw.text((bg_w//2, y_text), line, fill=(80, 80, 80, 255), font=body_font, anchor="mm")
-            y_text += 28
-
         # 저장
         merged_filename = f"moral_{uuid.uuid4().hex[:8]}.jpg"
         merged_filepath = os.path.join(Config.MERGED_DIR, merged_filename)

--- a/static/css/bookshelf.css
+++ b/static/css/bookshelf.css
@@ -1,5 +1,10 @@
 @import url('https://fonts.googleapis.com/css2?family=Jua&display=swap');
 
+@keyframes float-anim {
+  0%, 100% { transform: translateY(0px); }
+  50%       { transform: translateY(-10px); }
+}
+
 /* Global Reset & Container */
 body {
   margin: 0;
@@ -327,8 +332,8 @@ body {
   bottom: 25px;
   left: 50%;
   transform: translateX(-50%) !important;
-  width: 90%;
-  max-width: 460px;
+  width: 95%;
+  max-width: 600px;
   min-height: 80px;
   background: rgba(255, 255, 255, 0.98);
   backdrop-filter: blur(10px);
@@ -359,7 +364,7 @@ body {
 }
 
 .level-card.absolute-pos .level-progress-wrap {
-  width: 150px;
+  width: 220px;
   margin-top: 0;
 }
 
@@ -629,6 +634,7 @@ body {
   margin-top: 4px;
   font-size: 0.85rem;
   color: #999;
+  white-space: nowrap;
   font-weight: bold;
   text-align: right;
 }

--- a/static/js/bookshelf.jsx
+++ b/static/js/bookshelf.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { createRoot } from 'react-dom/client';
 import { motion, AnimatePresence } from 'framer-motion';
 
@@ -202,51 +202,127 @@ function StoryModal({ book, idx, onClose, onReadComplete }) {
   const currentPage = book.pages[currentPageIndex] || {};
   const currentPageContent = currentPage.content_kr || '';
 
-  // 현재 장면에 배치할 그림 결정 (storybook.js 의 mapToScenes 로직과 동일)
   const drawings = book.drawings || [];
-  const hit = mentionedInScene(currentPage.content_kr, drawings);
-  // 언급된 그림이 없으면 페이지 인덱스 기반으로 순환 배치 (항상 그림 표시)
-  const primaryDrawing   = hit[0] || (drawings.length > 0 ? drawings[currentPageIndex % drawings.length] : null);
-  const secondaryDrawing = hit[1] || (drawings.length > 1 ? drawings[(currentPageIndex + 1) % drawings.length] : null);
 
   function getDrawingSrc(d) {
     if (!d) return null;
     return nukkiMap[d.id] || (d.file_path ? '/' + d.file_path.replace(/^\/+/, '') : null);
   }
 
-  function bgImgTag(scene) {
-    if (scene && (scene.merged_image || scene.mergedMoralImage)) {
-      const src = scene.merged_image || scene.mergedMoralImage;
-      return `<img src="/${src.replace(/^\/+/, '')}" style="width:100%; height:100%; object-fit:cover; display:block;" alt="배경">`;
+  // 모든 페이지 그림 배치 사전 계산 (내용 우선, 미노출 그림 분배 → 최소 1회 보장, 최대 3개)
+  const pageAssignments = useMemo(() => {
+    const shownIds = new Set();
+    const result = book.pages.map(page => {
+      if (page.type !== 'content') return { primary: null, secondary: null, tertiary: null };
+      let primary = null, secondary = null, tertiary = null;
+      if (page.primaryDrawingId) primary = drawings.find(d => d.id === page.primaryDrawingId) || null;
+      if (page.secondaryDrawingId) secondary = drawings.find(d => d.id === page.secondaryDrawingId) || null;
+      if (!primary && !secondary) {
+        const hit = mentionedInScene(page.content_kr, drawings);
+        primary = hit[0] || null;
+        secondary = hit[1] || null;
+        tertiary = hit[2] || null;
+      }
+      if (primary) shownIds.add(primary.id);
+      if (secondary) shownIds.add(secondary.id);
+      if (tertiary) shownIds.add(tertiary.id);
+      return { primary, secondary, tertiary };
+    });
+    // 미노출 그림을 빈 슬롯에 분배
+    const unshown = drawings.filter(d => !shownIds.has(d.id));
+    for (const d of unshown) {
+      let placed = false;
+      for (let i = 0; i < result.length; i++) {
+        if (book.pages[i].type !== 'content') continue;
+        if (!result[i].secondary) { result[i].secondary = d; placed = true; break; }
+      }
+      if (!placed) {
+        for (let i = 0; i < result.length; i++) {
+          if (book.pages[i].type !== 'content') continue;
+          if (!result[i].tertiary) { result[i].tertiary = d; placed = true; break; }
+        }
+      }
+      if (!placed) {
+        for (let i = 0; i < result.length; i++) {
+          if (book.pages[i].type !== 'content') continue;
+          if (!result[i].primary) { result[i].primary = d; break; }
+        }
+      }
     }
-    return '';
-  }
+    return result;
+  }, [book.id]);
 
-  function renderDrawing(d, style) {
-    const src = getDrawingSrc(d);
-    if (!src) return null;
-    return (
-      <img
-        src={src}
-        alt={d.korean || ''}
-        style={{ position: 'absolute', maxWidth: '60%', maxHeight: '60%', objectFit: 'contain', ...style }}
-      />
-    );
-  }
-
-  // 왼쪽 페이지: 배경 + 누끼 그림 합성
+  // 왼쪽 페이지: 배경 + 그림 (교훈 페이지: 스케치북 배경 + 모든 그림, 내용 페이지: 배치된 1-2개)
   function renderLeftPage() {
+    const isMoralPage = currentPage.type === 'moral';
+
+    // ── 교훈(마지막) 페이지 ──────────────────────────────────────────────
+    if (isMoralPage) {
+      const dc = drawings.length;
+      const cols = dc === 1 ? 1 : 2;
+      const rows = dc <= 2 ? 1 : dc <= 4 ? 2 : 3;
+      const rotations = [-5, 4, -3, 6, -4];
+      return (
+        <div style={{ position:'relative', width:'100%', height:'100%', overflow:'hidden',
+                      borderRadius:'10px 0 0 10px', background:'linear-gradient(145deg,#fffde7,#fff9c4)' }}>
+          <img src="/static/images/sketchbook.png" alt="스케치북"
+            onLoad={e => { e.target.style.opacity='1'; }}
+            onError={e => { e.target.style.display='none'; }}
+            style={{ position:'absolute', inset:0, width:'100%', height:'100%',
+                     objectFit:'fill', zIndex:1, opacity:0, transition:'opacity 0.4s' }} />
+          <div style={{
+            position:'absolute', top:'20%', left:'8%', right:'8%', bottom:'18%', zIndex:3,
+            display:'grid',
+            gridTemplateColumns:`repeat(${cols}, 1fr)`,
+            gridTemplateRows:`repeat(${rows}, 1fr)`,
+            gap:'8px', boxSizing:'border-box', overflow:'hidden',
+          }}>
+            {drawings.map((d, i) => {
+              const src = getDrawingSrc(d);
+              const rot = rotations[i % rotations.length];
+              const spansAll = (dc % 2 !== 0) && (i === dc - 1) && dc > 1;
+              return (
+                <div key={d.id} style={{
+                  gridColumn: spansAll ? '1 / -1' : undefined,
+                  display:'flex', alignItems:'center', justifyContent:'center',
+                  overflow:'hidden',
+                  animation:`float-anim ${3 + i * 0.5}s ease-in-out ${i * 0.4}s infinite`,
+                }}>
+                  {src && <img src={src} alt={d.korean||''}
+                    style={{ maxWidth:'70%', maxHeight:'70%', objectFit:'contain',
+                             transform:`rotate(${rot}deg)`,
+                             filter:'drop-shadow(0 4px 12px rgba(0,0,0,0.28))' }} />}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      );
+    }
+
+    // ── 내용 페이지: 배치된 1-3개 그림 플로팅 ───────────────────────────
+    const { primary, secondary, tertiary } = pageAssignments[currentPageIndex] || {};
+    const pageDrawings = [primary, secondary, tertiary].filter(Boolean);
+    const dc = pageDrawings.length;
+    const maxH = dc === 1 ? '70vh' : dc === 2 ? '58vh' : '48vh';
+    const maxW = dc === 1 ? '90%' : dc === 2 ? '78%' : '65%';
+    // 그림 수에 따라 페이지 내 절대 위치 (top/left는 중심 기준, translate로 보정)
+    const POSITIONS = [
+      [{ top: '50%', left: '50%' }],
+      [{ top: '35%', left: '28%' }, { top: '62%', left: '72%' }],
+      [{ top: '25%', left: '50%' }, { top: '65%', left: '22%' }, { top: '68%', left: '76%' }],
+    ];
+    const positions = POSITIONS[Math.min(dc, 3) - 1] || POSITIONS[0];
+
     const bgImage = currentPage.bgImage;
     const bgText  = currentPage.bgText || '';
-    const mergedImage = currentPage.mergedImage || currentPage.mergedMoralImage;
-
-    // storybook.js 와 동일: 서버 저장 파일 우선 → Pollinations.ai 폴백
+    const mergedImage = currentPage.mergedImage;
     let bgSrc = null;
-    if (mergedImage) {
-        bgSrc = '/' + mergedImage.replace(new RegExp('^/+'), '');
-    } else if (bgImage) {
-        bgSrc = '/' + bgImage.replace(new RegExp('^/+'), '');
-    } else if (currentPage.type !== 'moral' && bgText) {
+    if (bgImage) {
+      bgSrc = '/' + bgImage.replace(/^\/+/, '');
+    } else if (mergedImage) {
+      bgSrc = '/' + mergedImage.replace(/^\/+/, '');
+    } else if (bgText) {
       const prompt = bgText
         + ', children storybook illustration, watercolor art style, soft pastel colors,'
         + ' magical whimsical background scenery, no characters, no people, no animals, no text';
@@ -255,53 +331,36 @@ function StoryModal({ book, idx, onClose, onReadComplete }) {
     }
 
     return (
-      <div style={{
-        position: 'relative', width: '100%', height: '100%',
-        overflow: 'hidden', borderRadius: '10px 0 0 10px',
-        display: 'flex', alignItems: 'center', justifyContent: 'center'
-      }}>
-        {/* 배경 — 로딩 중 스피너 표시 */}
+      <div style={{ position:'relative', width:'100%', height:'100%',
+                    overflow:'hidden', borderRadius:'10px 0 0 10px' }}>
         {bgSrc ? (
           <>
-            <div style={{ position:'absolute', inset:0, display:'flex', alignItems:'center', justifyContent:'center',
-              background:'linear-gradient(to bottom, #87ceeb, #5cbf8a)', zIndex:0 }}>
-              <span style={{ fontSize:'2rem', opacity:0.7 }}>🎨</span>
-            </div>
+            <div style={{ position:'absolute', inset:0, background:'linear-gradient(to bottom, #87ceeb, #5cbf8a)', zIndex:0 }} />
             <img src={bgSrc} alt="배경"
               onLoad={e => { e.target.style.opacity='1'; }}
               onError={e => { e.target.style.display='none'; }}
-              style={{ width:'100%', height:'100%', objectFit:'cover', display:'block',
-                       position:'relative', zIndex:1, opacity:0, transition:'opacity 0.4s' }} />
+              style={{ position:'absolute', inset:0, width:'100%', height:'100%',
+                       objectFit:'cover', display:'block', zIndex:1, opacity:0, transition:'opacity 0.4s' }} />
           </>
         ) : (
-          <div style={{ width: '100%', height: '100%', background: 'linear-gradient(to bottom, #87ceeb, #5cbf8a)' }} />
+          <div style={{ position:'absolute', inset:0, background:'linear-gradient(to bottom, #87ceeb, #5cbf8a)' }} />
         )}
-
-        {/* 그림 합성 — storybook.js 와 동일한 배치 규칙 적용 */}
-        {!mergedImage && primaryDrawing && !secondaryDrawing && (
-          isSky(primaryDrawing)
-            ? renderDrawing(primaryDrawing, { top: '8%', left: '50%', transform: 'translateX(-50%)' })
-            : renderDrawing(primaryDrawing, { bottom: '5%', left: '50%', transform: 'translateX(-50%)' })
-        )}
-        {!mergedImage && primaryDrawing && secondaryDrawing && (() => {
-          const pSky = isSky(primaryDrawing), sSky = isSky(secondaryDrawing);
-          if (!pSky && sSky) return (<>
-            {renderDrawing(primaryDrawing, { bottom: '5%', left: '20%' })}
-            {renderDrawing(secondaryDrawing, { top: '8%', right: '15%' })}
-          </>);
-          if (pSky && !sSky) return (<>
-            {renderDrawing(secondaryDrawing, { bottom: '5%', left: '20%' })}
-            {renderDrawing(primaryDrawing, { top: '8%', right: '15%' })}
-          </>);
-          if (!pSky && !sSky) return (<>
-            {renderDrawing(primaryDrawing, { bottom: '5%', left: '15%', maxWidth: '50%' })}
-            {renderDrawing(secondaryDrawing, { bottom: '5%', right: '10%', maxWidth: '38%' })}
-          </>);
-          return (<>
-            {renderDrawing(primaryDrawing, { top: '8%', left: '15%' })}
-            {renderDrawing(secondaryDrawing, { top: '8%', right: '15%' })}
-          </>);
-        })()}
+        {pageDrawings.map((d, i) => {
+          const src = getDrawingSrc(d);
+          if (!src) return null;
+          const pos = positions[i] || positions[0];
+          return (
+            <div key={d.id} style={{
+              position:'absolute', top: pos.top, left: pos.left,
+              transform:'translate(-50%, -50%)', zIndex:5,
+              animation:`float-anim ${3 + i * 0.7}s ease-in-out ${i * 0.5}s infinite`,
+            }}>
+              <img src={src} alt={d.korean||''}
+                style={{ maxHeight:maxH, maxWidth:maxW, objectFit:'contain',
+                         filter:'drop-shadow(0 4px 14px rgba(0,0,0,0.35))' }} />
+            </div>
+          );
+        })}
       </div>
     );
   }
@@ -521,7 +580,9 @@ function BookshelfApp() {
                 content_kr: scene ? scene.text : '',
                 bgImage: scene ? scene.bg_image : null,
                 bgText: (scene && scene.bg) || '',
-                mergedImage: spread.mergedImage
+                mergedImage: spread.mergedImage,
+                primaryDrawingId: spread.primaryDrawingId || null,
+                secondaryDrawingId: spread.secondaryDrawingId || null,
               });
             } else if (spread.type === 'moral') {
               mappedPages.push({

--- a/static/js/storybook.js
+++ b/static/js/storybook.js
@@ -367,16 +367,9 @@
       return 'sky';
     }
 
-    // 만약 서버에서 병합된 이미지가 있다면, 개별 드로잉 레이어링은 생략합니다.
-    const isMerged = !!(scene && scene.merged_image);
-
     let html = `<div class="scene-sky" style="background:${theme.sky};">${bgImgTag(scene)}</div>
       ${deco}
       <div class="scene-vignette"></div>`;
-
-    if (isMerged) {
-        return html;
-    }
 
     if (!primary && !secondary) {
       // 그림 없음
@@ -504,34 +497,124 @@
       </div>`;
     }
 
+    function makeMoralLeftDrawingsHTML(drawingsList, spec) {
+      const bgImgHtml = `<img src="/static/images/sketchbook.png" alt="스케치북" style="position:absolute;inset:0;width:100%;height:100%;object-fit:fill;z-index:1;" onerror="this.style.display='none'">`;
+      const list = drawingsList || [];
+      const count = list.length;
+
+      if (count === 0) {
+        return `<div style="position:relative;width:100%;height:100%;background:linear-gradient(145deg,#fffde7,#fff9c4);border-radius:10px 0 0 10px;overflow:hidden;">${bgImgHtml}</div>`;
+      }
+
+      const cols = count === 1 ? 1 : 2;
+      const rows = count <= 2 ? 1 : count <= 4 ? 2 : 3;
+      const rotations = [-5, 4, -3, 6, -4];
+
+      const items = list.map((d, i) => {
+        const rot = rotations[i % rotations.length];
+        const dur = (3 + i * 0.5).toFixed(1);
+        const del = (i * 0.4).toFixed(1);
+        const spansAll = (count % 2 !== 0) && (i === count - 1) && count > 1;
+        const gridCol = spansAll ? 'grid-column:1/-1;' : '';
+        // overflow:hidden 으로 회전 시 셀 밖으로 삐져나오는 것 방지
+        const wrapStyle = `${gridCol}display:flex;align-items:center;justify-content:center;overflow:hidden;animation:float-anim ${dur}s ease-in-out ${del}s infinite;`;
+
+        if (!d.file_path) {
+          return `<div style="${wrapStyle}"><span style="font-size:2.5rem;display:block;transform:rotate(${rot}deg);">${d.emoji||'🎨'}</span></div>`;
+        }
+        const src = d.nukkiUrl || ('/' + d.file_path.replace(/^\/+/, ''));
+        // max 70%: 회전(최대 6도) 시에도 셀 안에 완전히 들어오는 크기
+        return `<div style="${wrapStyle}">
+          <img src="${src}" alt="${d.korean||''}"
+            style="max-width:70%;max-height:70%;object-fit:contain;transform:rotate(${rot}deg);filter:drop-shadow(0 3px 10px rgba(0,0,0,0.25));"
+            onerror="this.style.display='none'">
+        </div>`;
+      }).join('');
+
+      return `<div style="position:relative;width:100%;height:100%;background:linear-gradient(145deg,#fffde7,#fff9c4);border-radius:10px 0 0 10px;overflow:hidden;">
+        ${bgImgHtml}
+        <div style="position:absolute;top:20%;left:8%;right:8%;bottom:18%;z-index:3;overflow:hidden;
+                    display:grid;grid-template-columns:repeat(${cols},1fr);
+                    grid-template-rows:repeat(${rows},1fr);gap:8px;box-sizing:border-box;">
+          ${items}
+        </div>
+      </div>`;
+    }
+
+    function makeMoralAndEndRightHTML() {
+      return `<div style="display:flex;flex-direction:column;align-items:center;gap:12px;width:100%;">
+        ${SD.moral
+          ? `<div class="moral-big-icon">💡</div>
+             <div class="moral-label-text">이야기의 교훈</div>
+             <p class="moral-body">${SD.moral}</p>`
+          : `<div class="moral-big-icon">📖</div><p class="moral-body">재미있는 이야기였나요?</p>`}
+        <div style="width:100%;height:1px;background:#eee;margin:4px 0;"></div>
+        <div class="end-actions">
+          <a href="/collection" class="btn btn-yellow">✨ 새 동화 만들기</a>
+          <a href="/library"    class="btn btn-blue">📚 도서관으로</a>
+          <button class="btn btn-white" id="delete-story-btn">🗑️ 삭제</button>
+        </div>
+      </div>`;
+    }
+
     if (layoutData && layoutData.spreads && layoutData.spreads.length > 0) {
+      // 1단계: content 스펙 수집
+      const contentItems = [];
+      for (const spec of layoutData.spreads) {
+        if (spec.type === 'content') {
+          const scene = spec.sceneIdx !== undefined && scenes ? scenes[spec.sceneIdx] : null;
+          const text  = (scene && scene.text) || paragraphs[spec.textPageNum - 1] || '';
+          contentItems.push({ spec, scene, text });
+        }
+      }
+
+      // 2단계: 그림 배분 계산 (모든 그림 최소 1회 보장)
+      const shownIds = new Set();
+      const assignments = contentItems.map(({ spec, text }) => {
+        let primary   = spec.primaryDrawingId   ? pDrawings.find(d => d.id === spec.primaryDrawingId)   : null;
+        let secondary = spec.secondaryDrawingId ? pDrawings.find(d => d.id === spec.secondaryDrawingId) : null;
+        if (!primary || !secondary) {
+          const hits = mentioned(text, pDrawings);
+          const used = new Set([primary && primary.id, secondary && secondary.id].filter(Boolean));
+          const extra = hits.filter(d => !used.has(d.id));
+          if (!primary   && extra.length > 0) primary   = extra[0];
+          else if (!secondary && extra.length > 0) secondary = extra[0];
+        }
+        if (primary)   shownIds.add(primary.id);
+        if (secondary) shownIds.add(secondary.id);
+        return { primary, secondary };
+      });
+
+      // 3단계: 미노출 그림을 빈 슬롯에 분배
+      for (const d of pDrawings.filter(d => !shownIds.has(d.id))) {
+        let placed = false;
+        for (const a of assignments) {
+          if (!a.secondary) { a.secondary = d; placed = true; break; }
+        }
+        if (!placed) {
+          for (const a of assignments) {
+            if (!a.primary) { a.primary = d; break; }
+          }
+        }
+      }
+
+      // 4단계: 페이지 빌드
+      let ci = 0;
       for (const spec of layoutData.spreads) {
         if (spec.type === 'cover') {
           const covScene = spec.sceneIdx !== undefined && scenes ? scenes[spec.sceneIdx] : (scenes ? scenes[0] : null);
           pages.push({ leftHTML: makeCoverLeftHTML(covScene), rightInnerHTML: makeCoverRightHTML() });
         } else if (spec.type === 'content') {
-          const scene = spec.sceneIdx !== undefined && scenes ? scenes[spec.sceneIdx] : null;
-          const text  = (scene && scene.text) || paragraphs[spec.textPageNum - 1] || '';
-          let primary   = spec.primaryDrawingId   ? pDrawings.find(d => d.id === spec.primaryDrawingId)   : null;
-          let secondary = spec.secondaryDrawingId ? pDrawings.find(d => d.id === spec.secondaryDrawingId) : null;
-
-          // layoutData에 없는 그림을 텍스트 언급으로 보완 (누락 방지)
-          if (!primary || !secondary) {
-            const textHits = mentioned(text, pDrawings);
-            const shownIds = new Set([primary && primary.id, secondary && secondary.id].filter(Boolean));
-            const extra = textHits.filter(d => !shownIds.has(d.id));
-            if (!primary   && extra.length > 0) primary   = extra[0];
-            else if (!secondary && extra.length > 0) secondary = extra[0];
-          }
-
+          const { scene, text } = contentItems[ci];
+          const { primary, secondary } = assignments[ci];
+          ci++;
           pages.push({
-            leftHTML:      makeDrawingPageHTML(primary, secondary, scene),
+            leftHTML:       makeDrawingPageHTML(primary, secondary, scene),
             rightInnerHTML: `<p class="story-text">${text}</p>`,
           });
         } else if (spec.type === 'moral') {
-          pages.push({ leftHTML: makeMoralLeftHTML(spec), rightInnerHTML: makeEndRightHTML() });
+          pages.push({ leftHTML: makeMoralLeftDrawingsHTML(pDrawings, spec), rightInnerHTML: makeMoralAndEndRightHTML() });
         }
-        // 'end' type은 moral에서 처리됨
       }
     } else {
       // 기존 로직 (layout_data 없는 구버전 스토리)
@@ -548,7 +631,7 @@
         });
       }
 
-      pages.push({ leftHTML: makeMoralLeftHTML(), rightInnerHTML: makeEndRightHTML() });
+      pages.push({ leftHTML: makeMoralLeftDrawingsHTML(pDrawings), rightInnerHTML: makeMoralAndEndRightHTML() });
     }
 
     // ── DOM refs ────────────────────────────────────────────────────────


### PR DESCRIPTION
- 마지막 페이지(교훈): 스케치북 배경 복원, 선택 그림 전체 그리드 플로팅
- 내용 페이지: 그림을 하단 고정에서 페이지 내 float-anim 분산 플로팅으로 변경
- 최대 3개 그림/페이지 지원 (tertiary 슬롯 추가, 미노출 그림 최소 1회 보장)
- image_service.py: 교훈 이미지에 텍스트 베이킹 제거 (프론트에서 직접 표시)
- 레벨 카드 너비 확장 및 진행 텍스트 한 줄 처리(white-space: nowrap)
- bookshelf.jsx, storybook.js 동일 동작으로 통일

## Summary
- **교훈 페이지 개선**: 스케치북 배경 복원 + 선택한 그림 전체가 흰 영역 안에서 그리드 플로팅 (overflow 클리핑, 회전 효과 포함)
- **내용 페이지 개선**: 그림을 하단 고정 flex에서 페이지 내 절대 위치 float-anim 플로팅으로 전환, 1~3개 분산 배치
- **그림 노출 보장**: 페이지당 최대 3개(tertiary 슬롯 추가), 선택한 모든 그림이 최소 1회 이상 등장
- **교훈 텍스트 분리**: Python에서 이미지에 텍스트를 굽는 방식 제거, 프론트에서 직접 렌더링
- **레벨 카드 UI**: 너비 확장(460→600px), 진행 텍스트 한 줄 표시

## Test plan
- [x] 그림 1~5개 선택 후 동화 생성 → 모든 그림이 내용 페이지에 최소 1회 노출 확인
- [x] 마지막 교훈 페이지 → 스케치북 흰 영역 안에 그림 전부 표시, 삐져나오지 않음 확인
- [ ] 도서관 모달(bookshelf.jsx) 동화 열기 → 동일하게 플로팅 동작 확인
- [ ] 레벨 카드 "꿈나무 작가까지 N권 남음" 한 줄 표시 확인
